### PR TITLE
Improve single quote replacement

### DIFF
--- a/macOS/Random scripts and config files/FindDuplicateMacDevices/Find-DuplicateMacDevices.ps1
+++ b/macOS/Random scripts and config files/FindDuplicateMacDevices/Find-DuplicateMacDevices.ps1
@@ -2102,7 +2102,7 @@ Write-Host -Object ""
 
 "@
             foreach ($target in $removeTargets) {
-                $displayName = $target.DisplayName -replace "'", "''"
+                $displayName = $target.DisplayName -replace "'", "''" -replace '([\u2018-\u201B])', '$1$1'
                 $userInfoLine = if ($target.PrimaryUser) {
                     $userSignIn = if ($target.PrimaryUserDaysSinceSignIn) { "$($target.PrimaryUserDaysSinceSignIn) days ago" } else { "N/A" }
                     "# User: $($target.PrimaryUser) ($($target.PrimaryUserStatus)) | User last sign-in: $userSignIn"
@@ -2148,7 +2148,7 @@ Write-Host -Object ""
 
 "@
             foreach ($target in $intuneRemoveTargets) {
-                $displayName = $target.DeviceName -replace "'", "''"
+                $displayName = $target.DeviceName -replace "'", "''" -replace '([\u2018-\u201B])', '$1$1'
                 $userInfoLine = if ($target.PrimaryUser) {
                     $userSignIn = if ($target.PrimaryUserDaysSinceSignIn) { "$($target.PrimaryUserDaysSinceSignIn) days ago" } else { "N/A" }
                     "# User: $($target.PrimaryUser) ($($target.PrimaryUserStatus)) | User last sign-in: $userSignIn"


### PR DESCRIPTION
There are some other quote characters (`‘`, `’`, `‚`, `‛`) which PowerShell treat as single quote. If a device display name contains such characters, the generated `cleanup_helper.ps1` script throws `ParseError` as a result.

This PR adds replacement logic for them.